### PR TITLE
Added QtCore.Framework

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('POB Frontend', 'cpp', default_options : ['cpp_std=c++11'])
 
-qt5_dep = dependency('qt5', modules : ['Gui'])
+qt5_dep = dependency('qt5', modules : ['Gui','Core'])
 lua_dep = dependency('luajit')
 # NB on OSX you also need to invoke meson like so, because luajit:
 # LDFLAGS="-pagezero_size 10000 -image_base 100000000" meson pobfrontend build


### PR DESCRIPTION
Without QtCore, meson can't compile a code. Had an error 'QThread' missing file.

MacOS 10.15.1